### PR TITLE
Ensure geom_magnify caches clean base plot

### DIFF
--- a/R/geom-magnify.R
+++ b/R/geom-magnify.R
@@ -187,6 +187,12 @@ NULL
 #'   geom_magnify(from = from, to = to) +
 #'   scale_color_brewer()
 #'
+#' Each `geom_magnify()` layer caches a clone of the current plot without any
+#' other magnification layers. This ensures every inset is rendered from the
+#' unmagnified base, so add all theming, scales and geoms before calling
+#' `geom_magnify()`. To bypass the cached plot, provide a separate ggplot via
+#' the `plot =` argument.
+#'
 #' # For more examples see https://github.com/hughjonesd/ggmagnify
 #'
 geom_magnify <- function (mapping = NULL,
@@ -246,7 +252,10 @@ geom_magnify <- function (mapping = NULL,
 
 #' @export
 ggplot_add.GeomMagnifyLayer <- function(object, plot, ...) {
-  object$geom$plot <- plot
+  base_plot <- plot_clone(plot)
+  base_plot$layers <- Filter(function(layer) ! inherits(layer, "GeomMagnifyLayer"),
+                             plot$layers)
+  object$geom$plot <- base_plot
   NextMethod()
 }
 
@@ -323,8 +332,14 @@ GeomMagnify <- ggproto("GeomMagnify", Geom,
     # == create the magnified plot =======================================
 
     if (is.null(plot)) {
-      plot <- self$plot
+      base_plot <- self$plot
+      if (is.null(base_plot)) {
+        cli::cli_abort("`geom_magnify()` could not locate the base plot. Did you add it to a ggplot object?")
+      }
+      plot <- plot_clone(base_plot)
       plot <- plot + inset_theme(axes = axes)
+    } else {
+      plot <- plot_clone(plot)
     }
     plot_gtable <- create_plot_gtable(plot, data = d1,
                                       recompute = recompute,

--- a/R/ggplot-utils.R
+++ b/R/ggplot-utils.R
@@ -28,7 +28,7 @@ constructor <- function (x) {
 
 
 plot_clone <- function (plot) {
-    p <- plot
+    p <- rlang::duplicate(plot, shallow = FALSE)
     p$scales <- plot$scales$clone()
     p
 }

--- a/man/geom_magnify.Rd
+++ b/man/geom_magnify.Rd
@@ -199,6 +199,12 @@ cleaner.
 }
 }
 
+\subsection{Layer workflow}{
+Each call to \code{geom_magnify()} caches a clone of the current plot without
+other magnification layers so that every inset renders from the unmagnified
+base. Add scales, themes and geoms before adding magnification layers, or pass a
+standalone ggplot via the \code{plot} argument to override the cached plot.}
+
 \subsection{Limitations}{
 \itemize{
 \item \code{geom_magnify()} uses masks. This requires R version 4.1.0 or higher, and
@@ -256,6 +262,12 @@ ggp +
 ggp +
   geom_magnify(from = from, to = to) +
   scale_color_brewer()
+
+# Each `geom_magnify()` layer caches a clone of the current plot without any
+# other magnification layers. This ensures every inset is rendered from the
+# unmagnified base, so add all theming, scales and geoms before calling
+# `geom_magnify()`. To bypass the cached plot, provide a separate ggplot via
+# the `plot =` argument.
 
 # For more examples see https://github.com/hughjonesd/ggmagnify
 }

--- a/tests/testthat/test-sf.R
+++ b/tests/testthat/test-sf.R
@@ -130,3 +130,44 @@ test_that("multiple", {
   )
 })
 
+
+test_that("geom_magnify viewports derive from the base plot", {
+  to1 <- c(-125, -105, 20, 30)
+  to2 <- c(-95, -75, 30, 45)
+
+  inset_plot <- ggpm +
+    geom_magnify(from = c(-115, -105, 30, 40), to = to1, expand = 0) +
+    geom_magnify(from = c(-90, -80, 35, 45), to = to2, expand = 0)
+
+  gt <- ggplotGrob(inset_plot)
+  panel <- gt$grobs[[which(gt$layout$name == "panel")]]
+  mg_children <- panel$childrenOrder[grepl("ggmagnify", panel$childrenOrder)]
+
+  expect_length(mg_children, 2L)
+
+  inset_viewports <- lapply(mg_children, function(nm) {
+    vp <- panel$children[[nm]]$children[["layout"]]$vp
+    c(
+      x = grid::convertX(vp$x, "native", valueOnly = TRUE),
+      y = grid::convertY(vp$y, "native", valueOnly = TRUE),
+      width = grid::convertWidth(vp$width, "native", valueOnly = TRUE),
+      height = grid::convertHeight(vp$height, "native", valueOnly = TRUE)
+    )
+  })
+
+  base_build <- ggplot_build(ggpm)
+  panel_params <- base_build$layout$panel_params[[1]]
+  coord <- base_build$layout$coord
+
+  expected_viewports <- lapply(list(to1, to2), function(to) {
+    limits <- data.frame(x = c(to[1], to[2]), y = c(to[3], to[4]))
+    limits_t <- coord$transform(limits, panel_params)
+    x_rng <- range(limits_t$x, na.rm = TRUE)
+    y_rng <- range(limits_t$y, na.rm = TRUE)
+    c(x = mean(x_rng), y = mean(y_rng),
+      width = diff(x_rng), height = diff(y_rng))
+  })
+
+  expect_equal(inset_viewports, expected_viewports, tolerance = 1e-6)
+})
+


### PR DESCRIPTION
## Summary
- clone the incoming ggplot and strip existing `GeomMagnifyLayer`s before caching it on new magnify layers
- deep-copy the cached plot when building insets, and document how to override the cache via the `plot=` argument
- cover the regression with a two-inset `geom_sf` test that inspects the inset viewports

## Testing
- `R --vanilla -q <<'EOF'
pkgload::load_all('.')
testthat::test_file('tests/testthat/test-sf.R', reporter = 'summary')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68dea8b0150483309cde8bb3aedb3b9f